### PR TITLE
hybi-07 fragmantation impl, message <= 65536 chars limit

### DIFF
--- a/lib/websocket-client.js
+++ b/lib/websocket-client.js
@@ -231,7 +231,8 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 			position: outIndex++,
 			type: Ti.Codec.TYPE_BYTE
 		});
-	}
+  }
+  /*
 	else if(length < BUFFER_SIZE) { // # write 2 byte length
 		Ti.Codec.encodeNumber({
 			source: (126 | 0x80),
@@ -247,7 +248,8 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 			byteOrder: Ti.Codec.BIG_ENDIAN
 		});
 		outIndex += 2;
-	}
+  }
+  */
 	else { //	# write 8 byte length
 		Ti.Codec.encodeNumber({
 			source: (127 | 0x80),

--- a/lib/websocket-client.js
+++ b/lib/websocket-client.js
@@ -493,7 +493,8 @@ WebSocket.prototype._read_callback = function(e) {
 		}
 		else {
 			this.buffer.copy(this._socketReadBuffer, this.bufferSize, 0, e.bytesProcessed);
-			this.bufferSize += e.bytesProcessed;
+      this.bufferSize += e.bytesProcessed;
+      this.buffer.length += e.bytesProcessed;
 			this._socketReadBuffer.clear();
 		}
 	}

--- a/lib/websocket-client.js
+++ b/lib/websocket-client.js
@@ -200,11 +200,24 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 		return false;
 	}
 	
-	// apply per frame compression
-	var out = Ti.createBuffer({ length: BUFFER_SIZE });
-	var outIndex = 0;
-
 	var data = d || ''; //compress(d)	// TODO
+  var length = Utils.byte_length(data);
+  var header_length = 2;
+  var mask_size = 6;
+
+  if(125 < length && length <= BUFFER_SIZE){
+    header_length += 2;
+  } else if(BUFFER_SIZE < length){
+    header_length += 8;
+  }
+
+  if(!this._masking_disabled){
+    header_length += 4;
+  }
+
+	// apply per frame compression
+	var out = Ti.createBuffer({ length: length + header_length + mask_size });
+	var outIndex = 0;
 	
 	var byte1 = opcode;
 	if(last_frame) { 
@@ -215,10 +228,8 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 		source: byte1,
 		dest: out,
 		position: outIndex++,
-		type: Ti.Codec.TYPE_BYTE,
+		type: Ti.Codec.TYPE_BYTE
 	});
-	
-	var length = Utils.byte_length(data);
 	
 	if(length <= 125) {
 		var byte2 = length;
@@ -298,15 +309,18 @@ WebSocket.prototype._mask_payload = function(out, outIndex, payload) {
 		var string = Ti.Codec.decodeString({
 			source: buffer,
 			charset: Ti.Codec.CHARSET_ASCII
-		});
+    });
+
+    if(out.length < length){
+  	  out.length = string.length;
+    }
 		
-		var masked_string = "";
 		for(i = 0; i < string.length; ++i) {
 			Ti.Codec.encodeNumber({
 				source: string.charCodeAt(i) ^ masking_key[i % 4],
 				dest: out,
 				position: outIndex++,
-				type: Ti.Codec.TYPE_BYTE,
+				type: Ti.Codec.TYPE_BYTE
 			});
 		}
 		return outIndex;
@@ -364,9 +378,57 @@ var parse_frame = function(buffer, size) {
 
 WebSocket.prototype.send = function(data) {
 	if(data && this.readyState === OPEN) {
-		var frame = this._create_frame(0x01, data);
-		var bytesWritten = this._socket.write(frame);
-		return bytesWritten > 0;
+    var buffer = Ti.createBuffer({ value: data });
+		var string = Ti.Codec.decodeString({
+			source: buffer,
+			charset: Ti.Codec.CHARSET_ASCII
+    });
+    var stringLength = string.length;
+    if(stringLength < BUFFER_SIZE){
+      var frame = this._create_frame(0x01, string);
+      var bytesWritten = this._socket.write(frame);
+      return 0 < bytesWritten;
+    }
+    // 
+    // fragment message
+    // http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07#section-4.7
+    //
+    var isFirstFragment = true;
+    var offset = 0;
+    while(offset < stringLength){
+      if(stringLength < (offset + BUFFER_SIZE)){
+        break;
+      }
+
+      fragment = string.substring(offset, BUFFER_SIZE);
+      if(fragment.length < 1){
+        return true;
+      }
+
+      // opcode:: fragment(0x80), text(0x01)
+      var opcode = 0x80;
+      if(isFirstFragment){
+        opcode = 0x01;
+        isFirstFragment = false;
+      }
+
+      frame = this._create_frame(opcode, fragment, false);
+      if(this._socket.write(frame) < 1){
+        return false;
+      }
+      offset += BUFFER_SIZE;
+    }
+    fragment = string.substring(offset, stringLength);
+    if(fragment.length < 1){
+      return true;
+    }
+
+    // last frame
+    frame = this._create_frame(0x80, fragment, true);
+    if(this._socket.write(frame) < 1){
+      return false;
+    }
+    return true;
 	}
 	else {
 		return false;

--- a/ti-websocket-client.js
+++ b/ti-websocket-client.js
@@ -871,7 +871,8 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 			position: outIndex++,
 			type: Ti.Codec.TYPE_BYTE
 		});
-	}
+  }
+  /*
 	else if(length < BUFFER_SIZE) { // # write 2 byte length
 		Ti.Codec.encodeNumber({
 			source: (126 | 0x80),
@@ -887,7 +888,8 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 			byteOrder: Ti.Codec.BIG_ENDIAN
 		});
 		outIndex += 2;
-	}
+  }
+  */
 	else { //	# write 8 byte length
 		Ti.Codec.encodeNumber({
 			source: (127 | 0x80),

--- a/ti-websocket-client.js
+++ b/ti-websocket-client.js
@@ -840,11 +840,24 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 		return false;
 	}
 	
-	// apply per frame compression
-	var out = Ti.createBuffer({ length: BUFFER_SIZE });
-	var outIndex = 0;
-
 	var data = d || ''; //compress(d)	// TODO
+  var length = Utils.byte_length(data);
+  var header_length = 2;
+  var mask_size = 6;
+
+  if(125 < length && length <= BUFFER_SIZE){
+    header_length += 2;
+  } else if(BUFFER_SIZE < length){
+    header_length += 8;
+  }
+
+  if(!this._masking_disabled){
+    header_length += 4;
+  }
+
+	// apply per frame compression
+	var out = Ti.createBuffer({ length: length + header_length + mask_size });
+	var outIndex = 0;
 	
 	var byte1 = opcode;
 	if(last_frame) { 
@@ -855,10 +868,8 @@ WebSocket.prototype._create_frame = function(opcode, d, last_frame) {
 		source: byte1,
 		dest: out,
 		position: outIndex++,
-		type: Ti.Codec.TYPE_BYTE,
+		type: Ti.Codec.TYPE_BYTE
 	});
-	
-	var length = Utils.byte_length(data);
 	
 	if(length <= 125) {
 		var byte2 = length;
@@ -938,15 +949,18 @@ WebSocket.prototype._mask_payload = function(out, outIndex, payload) {
 		var string = Ti.Codec.decodeString({
 			source: buffer,
 			charset: Ti.Codec.CHARSET_ASCII
-		});
+    });
+
+    if(out.length < length){
+  	  out.length = string.length;
+    }
 		
-		var masked_string = "";
 		for(i = 0; i < string.length; ++i) {
 			Ti.Codec.encodeNumber({
 				source: string.charCodeAt(i) ^ masking_key[i % 4],
 				dest: out,
 				position: outIndex++,
-				type: Ti.Codec.TYPE_BYTE,
+				type: Ti.Codec.TYPE_BYTE
 			});
 		}
 		return outIndex;
@@ -1004,9 +1018,57 @@ var parse_frame = function(buffer, size) {
 
 WebSocket.prototype.send = function(data) {
 	if(data && this.readyState === OPEN) {
-		var frame = this._create_frame(0x01, data);
-		var bytesWritten = this._socket.write(frame);
-		return bytesWritten > 0;
+    var buffer = Ti.createBuffer({ value: data });
+		var string = Ti.Codec.decodeString({
+			source: buffer,
+			charset: Ti.Codec.CHARSET_ASCII
+    });
+    var stringLength = string.length;
+    if(stringLength < BUFFER_SIZE){
+      var frame = this._create_frame(0x01, string);
+      var bytesWritten = this._socket.write(frame);
+      return 0 < bytesWritten;
+    }
+    // 
+    // fragment message
+    // http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07#section-4.7
+    //
+    var isFirstFragment = true;
+    var offset = 0;
+    while(offset < stringLength){
+      if(stringLength < (offset + BUFFER_SIZE)){
+        break;
+      }
+
+      fragment = string.substring(offset, BUFFER_SIZE);
+      if(fragment.length < 1){
+        return true;
+      }
+
+      // opcode:: fragment(0x80), text(0x01)
+      var opcode = 0x80;
+      if(isFirstFragment){
+        opcode = 0x01;
+        isFirstFragment = false;
+      }
+
+      frame = this._create_frame(opcode, fragment, false);
+      if(this._socket.write(frame) < 1){
+        return false;
+      }
+      offset += BUFFER_SIZE;
+    }
+    fragment = string.substring(offset, stringLength);
+    if(fragment.length < 1){
+      return true;
+    }
+
+    // last frame
+    frame = this._create_frame(0x80, fragment, true);
+    if(this._socket.write(frame) < 1){
+      return false;
+    }
+    return true;
 	}
 	else {
 		return false;
@@ -1071,7 +1133,8 @@ WebSocket.prototype._read_callback = function(e) {
 		}
 		else {
 			this.buffer.copy(this._socketReadBuffer, this.bufferSize, 0, e.bytesProcessed);
-			this.bufferSize += e.bytesProcessed;
+      this.bufferSize += e.bytesProcessed;
+      this.buffer.length += e.bytesProcessed;
 			this._socketReadBuffer.clear();
 		}
 	}


### PR DESCRIPTION
I'm implementation for hybi-07 fragmantation message(http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07#section-4.7)

and other problem patches below:
- read message <= 65536 chars limit.
- send message >= 48 chars braked frame data.
  issue "Messages >= 48 Chars Breaks the Connection":: nowelium/socket.io-titanium#8
