### PR TITLE
Update websocket-client.js

### DIFF
--- a/lib/websocket-client.js
+++ b/lib/websocket-client.js
@@ -164,7 +164,7 @@ var handshake_reponse = function(handshake) {
 
 WebSocket.prototype._check_handshake_response = function() {
 	var version = this.headers.shift();
-	if(version !== "HTTP/1.1 101 Switching Protocols") {
+	if(version.indexOf("HTTP/1.1 101") === -1){
 		// Mismatch protocol version
 		debug("mismatch protocol version");
 		return false;


### PR DESCRIPTION
The version checking is limited only for "HTTP/1.1 101 Switching Protocols" any other reason phrases as for example: "HTTP/1.1 101 Web Socket Protocol Handshake" are ignored.
